### PR TITLE
Add handling for multiple agents (spawn, assign, release)

### DIFF
--- a/Libraries/combadge-protocol/combadge.mjs
+++ b/Libraries/combadge-protocol/combadge.mjs
@@ -83,7 +83,7 @@ const InitPhase = {
  * This class contains the logic for exchanging CombadgePackets with a Combadge device, 
  */
 class Combadge{
-    constructor(MAC, IP, sourceUDPPort, packet, UDPServer) {
+    constructor (MAC, IP, sourceUDPPort, packet, UDPServer) {
         
         this.IP = IP;
         this.MAC = MAC;
@@ -113,45 +113,27 @@ class Combadge{
         settings.serial = this.serverSerial;
         this.sendCommandToBadge(settings);
 
+        this._agentPort = undefined;
+
         this.callState = "Idle";
     };
 
-    get agentInstance() {
-        return this._agentInstance;
-    }
+    get agentPort () {
+        return this._agentPort;
+    };
 
-    get agentPort() {
-        if (typeof this._agentPort !== 'undefined') {
-            return this._agentPort;
-        } else {
-            return false;
-        }
-    }
-
-    set agentPort(port) {
-        if (port == 0) {
-            delete this._agentPort;
-        } else {
-            this._agentPort = port;
-        }
-    }
-
-    set agentInstance(instance) {
-        if (this.agentPort == false) {
-            throw "Must set port before setting agent instance";
-        } else {
-            this._agentInstance = instance;
-        }
-    }
+    set agentPort (port) {
+        this._agentPort = port;
+    };
     
-    sendCommandToBadge(responsePacket) {
+    sendCommandToBadge (responsePacket) {
         console.log(`${this.MAC} ${this.getUserPrettyName()}: TX [${responsePacket.serial}] ${responsePacket.constructor.name} ${responsePacket.summary()}`);
         var compiledPacket = responsePacket.compile();
         this.UDPServer.send(compiledPacket, this.sourceUDPPort, this.IP);
 
     };
 
-    packetSorter(packet) {
+    packetSorter (packet) {
         console.log(`${this.MAC} ${this.getUserPrettyName()}: RX [${packet.serial}] ${packet.constructor.name} ${packet.summary()}`);
         this.badgeSerial = packet.serial;
 
@@ -225,17 +207,9 @@ class Combadge{
     };
 
     /**
-     * Callback for an Agent (or other software) to instruct the Combadge
-     * instance on what to do.
-     */
-    inferenceSorter (){
-
-    };
-
-    /**
      * Provide the name of the current logged in user.
      */
-     getUserPrettyName() {
+     getUserPrettyName () {
         //var user = this.User;
         return "Inactive";
     };
@@ -244,8 +218,16 @@ class Combadge{
     /**
      * Append a new serial to the serial list.
      */
-    incrementSerial() {
+    incrementSerial () {
         this.serverSerial += 1;
+    };
+
+    /**
+     * Callback for an Agent (or other software) to instruct the Combadge
+     * instance on what to do.
+     */
+    externalCallback (instruction) {
+
     };
 };
 

--- a/Libraries/combadge-protocol/combadge_packet.mjs
+++ b/Libraries/combadge-protocol/combadge_packet.mjs
@@ -70,13 +70,13 @@ const VozServerCommands = {
  * 
  * Is quicker, someone let me know and I'll substitute it.
  */
- const VozBadgeCommands = function(serverCommands) {
+ const VozBadgeCommands = function (serverCommands) {
     var badgeCommands = {};
-    for(var command in serverCommands){
+    for (var command in serverCommands) {
         badgeCommands[serverCommands[command]] = command;
     };
     return badgeCommands;
-}(VozServerCommands);
+} (VozServerCommands);
 
 const VozAudioProtocol = {
     RTP: "0400",
@@ -149,7 +149,7 @@ function stringByteLength (string) {
      
     _serial = new String();
 
-    constructor(macAddress) {
+    constructor (macAddress) {
         this.MAC = macAddress
     }
 
@@ -227,7 +227,7 @@ function stringByteLength (string) {
  * Cannot be compiled, only ever received from the badge, never sent to it.
  */
 class Ping extends CombadgePacket {
-    constructor(MAC, {propertyVersion = EmptySetting, firmwareVersion = EmptySetting, packetData = {}} = {}) {
+    constructor (MAC, {propertyVersion = EmptySetting, firmwareVersion = EmptySetting, packetData = {}} = {}) {
         super(MAC);
         this.propertyVersion = propertyVersion;
         this.firmwareVersion = firmwareVersion;
@@ -237,11 +237,11 @@ class Ping extends CombadgePacket {
         this.prettyName = packetData.prettyName;
     };
 
-    summary() {
+    summary () {
         return `AP: ${this.accessPoint}, login: ${this.userName}, name: ${this.prettyName}`;
     };
 
-    static from(structuredPacket) {
+    static from (structuredPacket) {
         var MAC = structuredPacket.MAC;
         var packetSerial = structuredPacket.serial;
         var propertyVersion = parseInt(structuredPacket.firstSetting, 16);
@@ -293,7 +293,7 @@ class Ack extends CombadgePacket {
         this.sendAudio = sendAudio;
     };
 
-    summary() {
+    summary () {
         if (this.sendTime) {
             return `Sending Timestamp`;
         } else {
@@ -301,7 +301,7 @@ class Ack extends CombadgePacket {
         };
     };
 
-    static from(structuredPacket) {
+    static from (structuredPacket) {
         var MAC = structuredPacket.MAC;
         var packetSerial = structuredPacket.serial;
         var propertyVersion = parseInt(structuredPacket.firstSetting, 16);
@@ -313,7 +313,7 @@ class Ack extends CombadgePacket {
         return returnPacket;
     };
 
-    compile() {
+    compile () {
         if (this.sendTime) {
             var unixtime = Date.now() / 1000 | 0;
             var data = `${unixtime.toString(16)}0000012b`;
@@ -347,11 +347,11 @@ class Ack extends CombadgePacket {
         super(MAC);
     };
 
-    summary() {
+    summary () {
         return `Packet design incomplete. No summary available.`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.NewMessageA,
             firstSetting: EmptySetting,
@@ -372,11 +372,11 @@ class BadgeSettings extends CombadgePacket {
         super(MAC);
     };
 
-    summary() {
+    summary () {
         return `Packet design incomplete. No summary available.`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.SetBadgeSettings,
             firstSetting: EmptySetting,
@@ -395,7 +395,7 @@ class CallPressed extends CombadgePacket {
         this.callState = callState;
     };
 
-    summary() {
+    summary () {
         if (this.callState) {
             return `Dialling in progress.`;
         } else {
@@ -403,7 +403,7 @@ class CallPressed extends CombadgePacket {
         };
     };
 
-    static from(structuredPacket) {
+    static from (structuredPacket) {
         var MAC = structuredPacket.MAC;
         var packetSerial = structuredPacket.serial;
         var propertyVersion = parseInt(structuredPacket.firstSetting, 16);
@@ -424,11 +424,11 @@ class ErBits extends CombadgePacket {
         this.erbits = erbits;
     };
 
-    summary() {
+    summary () {
         return `Packet design incomplete. No summary available.`;
     };
 
-    static from(structuredPacket) {
+    static from (structuredPacket) {
         var MAC = structuredPacket.MAC;
         var packetSerial = structuredPacket.serial;
         var propertyVersion = parseInt(structuredPacket.firstSetting, 16);
@@ -450,11 +450,11 @@ class BadgeLogs extends CombadgePacket {
         this.badgeLogs = badgeLogs;
     };
 
-    summary() {
+    summary () {
         return `Packet design incomplete. No summary available.`;
     };
 
-    static from(structuredPacket) {
+    static from (structuredPacket) {
         var MAC = structuredPacket.MAC;
         var packetSerial = structuredPacket.serial;
         var propertyVersion = parseInt(structuredPacket.firstSetting, 16);
@@ -477,11 +477,11 @@ class BadgeLogs extends CombadgePacket {
         this.displayString = displayString;
     };
 
-    summary() {
+    summary () {
         return `Setting display to: ${this.displayString}`;
     };
 
-    compile() {
+    compile () {
         var displayString = unicodeToHex(this.displayString);
         var displayStringLength = stringByteLength(displayString);
         var endPadding = "".padEnd(12,"00");
@@ -508,11 +508,11 @@ class CallRTP extends CombadgePacket {
         this.targetPort = port;
     };
 
-    summary() {
+    summary () {
         return `Calling RTP host at ${this.targetAddress}:${this.targetPort}`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.CallRTPTarget,
             firstSetting: EmptySetting,
@@ -528,11 +528,11 @@ class HangUp extends CombadgePacket {
         super(MAC);
     };
 
-    summary() {
+    summary () {
         return `Ending active call.`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.HangUp,
             firstSetting: EmptySetting,
@@ -550,11 +550,11 @@ class LogIn extends CombadgePacket {
         this.prettyString = unicodeToHex (prettyName);
     };
 
-    summary() {
+    summary () {
         return `Packet design incomplete. No summary available.`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.UserLogIn,
             firstSetting: EmptySetting,
@@ -571,11 +571,11 @@ class LogOut extends CombadgePacket {
         super(MAC);
     };
 
-    summary() {
+    summary () {
         return `Logging user out.`;
     };
 
-    compile() {
+    compile () {
         var values = {
             command: VozServerCommands.UserLogOut,
             firstSetting: EmptySetting,
@@ -597,11 +597,11 @@ class PromptText extends CombadgePacket {
         this.prompt = prompt;
     };
 
-    summary() {
+    summary () {
         return `Sending prompt: ${this.prompt}`;
     };
 
-    compile() {
+    compile () {
         var promptText = "Prompt: " + this.prompt
         var promptString = unicodeToHex(promptText);
         var values = {
@@ -618,7 +618,7 @@ class PromptText extends CombadgePacket {
  * Send badge the name of the current AP. Currently just stubbing this out. We need to actuall manage AP names before we can give real ones.
  */
 /*
-sendAPName() {
+sendAPName () {
 
     var accessPointName = new String("Test APNAME");
     var accessPointName = unucify(accessPointName);

--- a/Libraries/robin-agent/robin.mjs
+++ b/Libraries/robin-agent/robin.mjs
@@ -42,14 +42,14 @@ console.error('Loaded model.');
  * Currently stubbed.
  */
 class Agent {
-    constructor(responseHook) {
-        this.responseHook = responseHook; // A function to call back to the parent Combadge to give instructions such as "call another badge".
+    constructor (callback = undefined) {
         this.samples = []
         this.recSamples = []
         this.transcoding = false;
+        this._callback = callback;
     };
 
-    recogniseBatch() {
+    recogniseBatch () {
         console.log("Transcoding, please wait.")
         this.transcoding = true;
         var floatSamples=Float32Array.from(Float32Array.from(this.recSamples).map(x=>x/0x8000));
@@ -58,9 +58,9 @@ class Agent {
         var wav16buffer = new Buffer.from(samples1616.buffer);
         console.log("Result:", model.stt(wav16buffer));
         this.transcoding = false;
-    }
+    };
 
-    receiveSamples(samples) {
+    receiveSamples (samples) {
         if (this.transcoding == false) {
             this.samples.push(...samples);
         }
@@ -70,6 +70,15 @@ class Agent {
             this.recogniseBatch();
         }
         return true;
+    };
+
+    set callback (callback = undefined) {
+        // Future task - verify that callback is either undefined or a function here.
+        this._callback = callback;
+    }
+
+    get callback () {
+        return this._callback;
     }
 };
 


### PR DESCRIPTION
This code needs call-level testing (my active lab is not local to me) but does execute and assign agents to badges without crashing.

This change should allow multiple badges to start agent calls in parallel with independent transcription of their recorded speech.