### PR TITLE
Implement api-triggered logout.

### DIFF
--- a/Libraries/combadge-protocol/combadge.mjs
+++ b/Libraries/combadge-protocol/combadge.mjs
@@ -131,12 +131,16 @@ class Combadge{
         return this._user;
     };
 
-    set user (ident = new UserIdent("u-setuser", "SetUser Called")) {
+    set user (ident = undefined) {
         this._user = ident;
         this.incrementSerial();
-        var login = new packets.LogIn(this.MAC, this._user);
-        login.serial = this.serverSerial;
-        this.sendCommandToBadge(login);
+        if (this._user) {
+            var action = new packets.LogIn(this.MAC, this._user);
+        } else {
+            var action = new packets.LogOut(this.MAC);
+        };
+        action.serial = this.serverSerial;
+        this.sendCommandToBadge(action);
     };
 
     /**
@@ -193,10 +197,7 @@ class Combadge{
                     // If user has enabled patrol mode, record to track log.
                     // Send badge new AP pretty name.
                 } else if (!this.loginState) {
-                    this.incrementSerial();
-                    var login = new packets.LogIn(this.MAC, new UserIdent("u-mobrien", "Miles O'Brien"));
-                    login.serial = this.serverSerial;
-                    this.sendCommandToBadge(login);
+                    this.loginState == false;
                 };
 
                 // If AP has not changed, do nothing.
@@ -274,12 +275,17 @@ class Combadge{
      * 
      * Initially this will be hooked to a basic restful web API so we can manually tell the badge what to do without the agent being involved.
      */
-    externalCallback (instruction, values) {
+    externalCallback (instruction, values={}) {
         switch(instruction) {
             case "login":
-                console.log("API request user change", this.MAC, values)
+                console.log("API request badge login", this.MAC, values);
                 this.user = new UserIdent(values.userName, values.prettyName);
-            break;
+                break;
+
+            case "logout":
+                console.log("API request badge logout", this.MAC);
+                this.user = undefined;
+                break;
 
             default:
         };

--- a/Libraries/combadge-protocol/combadge_packet.mjs
+++ b/Libraries/combadge-protocol/combadge_packet.mjs
@@ -222,7 +222,6 @@ function stringByteLength (string) {
     toBuffer (values) {
 
         var hexPackedPacket = VozIdent + values.command + values.firstSetting + values.secondSetting + this.hexSerial + this.MAC + values.data;
-        console.log(hexPackedPacket);
         return Buffer.from(hexPackedPacket, 'hex');
     }
 };

--- a/Libraries/combadge-protocol/identifier.mjs
+++ b/Libraries/combadge-protocol/identifier.mjs
@@ -74,7 +74,6 @@ class UserIdent extends Identifier {
     toBuffer() {
         var userBuffer = super.toBuffer(this._userName);
         var prettyBuffer = super.toBuffer(this._prettyName);
-        console.log(Buffer.concat([userBuffer, prettyBuffer]).toString('hex'));
         return Buffer.concat([userBuffer, prettyBuffer]);
     };
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The application is single-licenced under the Affero GPL v3.0, a copyleft licence
 
 - If you manually configure a B2000, B3000 or B3000n badge of the right firmware version using the on-device configuration menu, and run this software on a server connected to the right IP with the right ssid and password... you can probably get some really bad speech recognition output. Pretty good for a hobby project! If you have multiple badges you should also be able to manually trigger a badge-badge call through the web API.
 - The controller code will handle the existence of multiple badges, and will transcribe each stream fully independently. So far, the transcription is terrible and nothing is done with it - but it is technically functional.
-- There is a rudimentary self-describing API at port 1031. You can send the json `{"userName":"u-jdax","prettyName":"Jadzia Dax"}` or similar to the `/badge/:macaddress/user` endpoint on the api to change user on a badge.
+- There is a rudimentary self-describing API at port 1031. You can send the json `{"userName":"u-jdax","prettyName":"Jadzia Dax"}` or similar to the `/badge/:macaddress/user` endpoint on the api to change user on a badge. Sending an empty body (as in, `{}`) to the same endpoint will log out the badge. As an example: `curl -H "Content-Type: application/json" -d '{"userName":"u-wsomogh","prettyName":"Worf, Son of Mogh"}'  http://servername:1031/badges/0009efabcdef/user`
 - Should work on Node 12, 14, 16? I've not been too brave. Doesn't work on node 18 due to STT issues.
 - Now requires AVX! THANKS, tflite. You'll run on a Pi 02, but not a brand new Atom or a Westmere Xeon... P.S. You can manually compile tflite, but blegh.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/Combadge/Spindoctor#readme",
   "dependencies": {
     "alawmulaw": "^6.0.0",
-    "body-parser": "^1.20.1",
     "express": "^4.18.2",
     "node-vad": "^1.1.4",
     "stt": "^1.4.0",


### PR DESCRIPTION
To-Do list for this PR: 


* Properly validate requests to `/badge/:macaddress/user` and switch between login/logout.
* Properly implement `combadge_packet.LogOut`,
* Implement a trigger in `combadge.Combadge` to send a LogOut when requested by the API.
* Test the above!