### PR TITLE
Implement quickest, dirtiest method to start a badge to badge call.

### DIFF
--- a/Libraries/combadge-protocol/combadge.mjs
+++ b/Libraries/combadge-protocol/combadge.mjs
@@ -270,6 +270,17 @@ class Combadge{
     };
 
     /**
+     * Call a specific RTP Target.
+     */
+    callTarget (address, port) {
+        this.incrementSerial();
+        var callAgent = new packets.CallRTP(this.MAC, {address: address, port: port});
+        callAgent.serial = this.serverSerial;
+        this.sendCommandToBadge(callAgent);
+        this.callState = "Active";
+    };
+
+    /**
      * Callback for an Agent (or other software) to instruct the Combadge
      * instance on what to do.
      * 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The application is single-licenced under the Affero GPL v3.0, a copyleft licence
 
 ## Current State ##
 
-- If you manually configure a B2000, B3000 or B3000n badge of the right firmware version using the on-device configuration menu, and run this software on a server connected to the right IP with the right ssid and password... you can probably get some really bad speech recognition output. Pretty good for a hobby project! If you have multiple badges you should also be able to manually trigger a badge-badge call through the web API.
+- If you manually configure a B2000, B3000 or B3000n badge of the right firmware version using the on-device configuration menu, and run this software on a server connected to the right IP with the right ssid and password... you can probably get some really bad speech recognition output. Pretty good for a hobby project!
 - The controller code will handle the existence of multiple badges, and will transcribe each stream fully independently. So far, the transcription is terrible and nothing is done with it - but it is technically functional.
 - There is a rudimentary self-describing API at port 1031. You can send the json `{"userName":"u-jdax","prettyName":"Jadzia Dax"}` or similar to the `/badge/:macaddress/user` endpoint on the api to change user on a badge. Sending an empty body (as in, `{}`) to the same endpoint will log out the badge. As an example: `curl -H "Content-Type: application/json" -d '{"userName":"u-wsomogh","prettyName":"Worf, Son of Mogh"}'  http://servername:1031/badges/0009efabcdef/user`
+- The API also allows you to make badge to badge calls, currently only between pairs of badges (multicast grouping is not supported). As an example `curl -H "Content-Type: application/json" -d '{"targetMAC":"0009effedcba"}' http://servername:1031/badges/0009efabcdef/callTarget`. The code is *very* oversimplified, and the API is likely to change in short order.
 - Should work on Node 12, 14, 16? I've not been too brave. Doesn't work on node 18 due to STT issues.
 - Now requires AVX! THANKS, tflite. You'll run on a Pi 02, but not a brand new Atom or a Westmere Xeon... P.S. You can manually compile tflite, but blegh.
 

--- a/combadged.js
+++ b/combadged.js
@@ -160,6 +160,18 @@ app.get('/badges/:badgeMAC', (request, responder) => {
     return responder.send(activeBadges[request.params.badgeMAC]);
 });
 
+app.post('/badges/:badgeMAC/callTarget', (request, responder) => {
+    if ("targetMAC" in request.body) {
+        var initiator = activeBadges[request.params.badgeMAC];
+        var target = activeBadges[request.body["targetMAC"]];
+        console.log(`${target.IP} calling ${initiator.IP}`);
+        initiator.callTarget(target.IP, 5200);
+        target.callTarget(initiator.IP, 5200);
+    };
+
+    return responder.send([true]);
+});
+
 app.post('/badges/:badgeMAC/user', (request, responder) => {
     if (!(request.params.badgeMAC in activeBadges)) {
         responder.status(404);


### PR DESCRIPTION
I've been frustrated the last few weeks with this not being in place, so I'm going to be more agile, and implement the smallest version of this that I can, and clean it up in later PR's.